### PR TITLE
fixed wrong tag in docker push command

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -45,5 +45,5 @@ jobs:
       # Push both images to Dockerhub
       - name: Push image to Dockerhub
         run: |
-          docker push ${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
+          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           docker push ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
this PR fixes a CI error on the `docker push` command with the correct tag